### PR TITLE
WIP: Remove sliding expiry on cookie

### DIFF
--- a/src/SAML2/Config/IdentityProviderCollection.cs
+++ b/src/SAML2/Config/IdentityProviderCollection.cs
@@ -354,7 +354,6 @@ namespace SAML2.Config
             catch (Exception e)
             {
                 // Probably not a metadata file.
-                Logging.LoggerProvider.LoggerFor(GetType()).Error("Problem parsing metadata file", e);
                 return null;
             }
         }

--- a/src/SAML2/Protocol/Saml20SignonHandler.cs
+++ b/src/SAML2/Protocol/Saml20SignonHandler.cs
@@ -248,6 +248,9 @@ namespace SAML2.Protocol
             }
 
             Logger.Debug(TraceMessages.ReplaceAttackCheckCleared);
+
+            // Clear InResponseTo once its checked
+            StateService.Remove(ExpectedInResponseToSessionKey);
         }
 
         /// <summary>

--- a/src/SAML2/State/CacheStateService.cs
+++ b/src/SAML2/State/CacheStateService.cs
@@ -125,6 +125,41 @@ namespace SAML2.State
             return string.Format("{0}-{1}", GetCacheKeyPrefix(context), key);
         }
 
+        private static bool DisallowsSameSiteNone(string userAgent)
+        {
+            // Cover all iOS based browsers here. This includes:
+            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+            // All of which are broken by SameSite=None, because they use the iOS networking stack
+            if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+            {
+                return true;
+            }
+
+            // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+            // - Safari on Mac OS X.
+            // This does not include:
+            // - Chrome on Mac OS X
+            // Because they do not use the Mac OS networking stack.
+            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+            {
+                return true;
+            }
+
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // and none in this range require it.
+            // Note: this covers some pre-Chromium Edge versions, 
+            // but pre-Chromium Edge does not require SameSite=None.
+            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Gets the decrypted ticket value.
         /// </summary>
@@ -187,7 +222,10 @@ namespace SAML2.State
                 };
             
             // Hack to support SameSite as SAML POST flow fails this check
-            cookie.Path += "; SameSite=None";
+            if (DisallowsSameSiteNone(context.Request.UserAgent) == false)
+            {
+                cookie.Path += "; SameSite=None";
+            }
 
             context.Response.SetCookie(cookie);
 

--- a/src/SAML2/State/CacheStateServiceFactory.cs
+++ b/src/SAML2/State/CacheStateServiceFactory.cs
@@ -15,7 +15,7 @@ namespace SAML2.State
         /// <summary>
         /// Cache state service instance.
         /// </summary>
-        private static readonly IInternalStateService CacheStateService = new CacheStateService(HttpContext.Current, Saml2Config.GetConfig().State.Settings.FirstOrDefault(x => x.Name == "cacheExpiration").Value);
+        private static readonly IInternalStateService CacheStateService = new CacheStateService(HttpContext.Current, Saml2Config.GetConfig().State.Settings.FirstOrDefault(x => x.Name == "cacheExpiration")?.Value);
 
         #endregion
 

--- a/src/SAML2/State/StateServiceProvider.cs
+++ b/src/SAML2/State/StateServiceProvider.cs
@@ -34,8 +34,15 @@ namespace SAML2.State
         static StateServiceProvider()
         {
             var stateServiceClass = Saml2Config.GetConfig().State.StateServiceFactory;
-            var stateServiceFactory = string.IsNullOrEmpty(stateServiceClass) ? new SessionStateServiceFactory() : GetStateServiceFactory(stateServiceClass);
-            SetStateServiceFactory(stateServiceFactory);
+
+            if (Saml2Config.GetConfig().State != null && !string.IsNullOrEmpty(stateServiceClass))
+            {
+                SetStateServiceFactory(GetStateServiceFactory(stateServiceClass));
+            }
+            else
+            {
+                SetStateServiceFactory(new CacheStateServiceFactory());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The SetCookie call when made during the later requests in the flow was
failing with an Exception due to the HTTP headers already being sent. I
wasn't able to get to the bottom of when the headers were being sent but
this is a workaround in order to test this as a PoC.